### PR TITLE
Use colorize instead of colored.

### DIFF
--- a/capistrano-measure.gemspec
+++ b/capistrano-measure.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "capistrano", ">= 2", "< 4"
-  spec.add_dependency "colored", "~> 1.2"
+  spec.add_dependency "colorize"
 
   spec.add_development_dependency "bundler", "~> 1.7"
   spec.add_development_dependency "rake", "~> 10.0"

--- a/lib/capistrano/measure/log_reporter.rb
+++ b/lib/capistrano/measure/log_reporter.rb
@@ -1,4 +1,4 @@
-require 'colored'
+require 'colorize'
 require 'logger'
 
 module Capistrano


### PR DESCRIPTION
Hi, this gem help me a lot though I got the following error since this gem
 depends on [colored](https://github.com/defunkt/colored).

It looks like colored doesn't work nice when we use any other gem which depends on [colorize](https://github.com/fazibear/colorize/blob/master/colorize.gemspec)

(Refers: https://github.com/mattheworiordan/capybara-screenshot/pull/111)

So I added colorize instead of colored.

Thanks.

---
### Error

```
TypeError: no implicit conversion of Hash into String
/Users/bob/.rbenv/versions/2.2.2/gemsets/my_project/gems/colored-1.2/lib/colored.rb:72:in `colorize'
/Users/bob/.rbenv/versions/2.2.2/gemsets/my_project/gems/colorize-0.7.7/lib/colorize/class_methods.rb:94:in `block (2 levels) in color_methods'
/Users/bob/.ghq/github.com/AMekss/capistrano-measure/lib/capistrano/measure/log_reporter.rb:18:in `render'
```