### PR TITLE
Colorize min version requirement

### DIFF
--- a/capistrano-measure.gemspec
+++ b/capistrano-measure.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "capistrano", ">= 2", "< 4"
-  spec.add_dependency "colorize"
+  spec.add_dependency "colorize", '>= 0.8.1'
 
   spec.add_development_dependency "bundler", "~> 1.7"
   spec.add_development_dependency "rake", "~> 10.0"


### PR DESCRIPTION
Require 0.8.1 because ColorizeString used was created in that version and all previous are incompatible