### PR TITLE
Misordered / missing events kill deployments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@
 *.o
 *.a
 mkmf.log
+.idea

--- a/spec/capistrano/measure/timer_spec.rb
+++ b/spec/capistrano/measure/timer_spec.rb
@@ -74,15 +74,17 @@ describe Capistrano::Measure::Timer do
       expect(event.indent).to eq 0
     end
 
-    it "should raise exception with unstarted event" do
-      expect{ subject.stop('test123') }.to raise_error(RuntimeError)
+    it "should report error with unstarted event" do
+      subject.should_receive(:report_missing_event_start).once
+      subject.stop('test123')
     end
   end
 
   describe "#report_events" do
-    it "should raise exception if called in the middle of process" do
+    it "should report an error if called in the middle of process" do
       subject.start('test')
-      expect{ subject.report_events }.to raise_error(RuntimeError)
+      subject.should_receive(:report_open_events).once
+      subject.report_events
     end
 
     context "in completed state" do


### PR DESCRIPTION
Do not raise exceptions and kill deployments for unfound or misordered events, because the exception will stop a deployment and then you can't measure _any_ aspect of it.

At Avvo we're seeing this fail our deployment on an app restart task.  This is probably a race condition because it happens very quickly.  This fixed things for us.  We might not even need to be outputting the error in this case, because a task happening that fast is just a 0-time thing.

Also the error was hard to find - there was no way to see it came from this gem.  I added capistrano/measure to the output so we can always know right where it's from.  Otherwise it could be our app / rails / capistrano / other gems ...
